### PR TITLE
Develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ units:
 | Norwegian        | no      |
 | Polish           | pl      |
 | Portuguese       | pt      |
+| Romanian         | ro      |
 | Russian          | ru      |
 | Slovak           | sk      |
 | Spanish          | es      |

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ HACS is a third party community store and is not included in Home Assistant out 
 | show_wind_speed       | boolean | true                     | Show or hide wind_speed on the card.                                                               |
 | show_feels_like       | boolean | false                    | Show or hide feels like temperature on the card.                                                   |
 | show_description      | boolean | false                    | Show or hide the weather description on the card.                                                  |
+| use_12hour_format     | boolean | false                    | Display time in 12-hour format (AM/PM) instead of 24-hour format.                                  |
 | icons                 | string  | none                     | Path to the location of custom icons in svg format, for example `/local/weather-icons/`.           |
 | animated_icons        | boolean | false                    | Enable the use of animated icons                                                                   |
 | icon_style            | string  | 'style1'                 | Options are 'style1' and'style2' for different set of animated icons.                              |
@@ -74,7 +75,6 @@ HACS is a third party community store and is not included in Home Assistant out 
 | round_temp           | boolean | false                    | Option for rounding the forecast temperatures                                                      |
 | style                | string  | style1                   | Change chart style, options: 'style1' or 'style2'                                                  |
 | type                 | string  | daily                    | Show daily or hourly forecast if available, options: 'daily' or 'hourly'                           |
-| use_12hour_format    | boolean | false                    | Display time in 12-hour format (AM/PM) instead of 24-hour format.                                  |
 
 ##### Units of measurement
 

--- a/dist/weather-chart-card.js
+++ b/dist/weather-chart-card.js
@@ -17735,6 +17735,9 @@ subscribeForecastEvents() {
 
   constructor() {
     super();
+    window.addEventListener('orientationchange', () => {
+      this.measureCard();
+    });
   }
 
 ll(str) {

--- a/dist/weather-chart-card.js
+++ b/dist/weather-chart-card.js
@@ -17964,7 +17964,7 @@ drawChart({ config, language, weather, forecastItems } = this) {
   }
 
   const ctx = canvas.getContext('2d');
-  const precipMax = mode === 'hourly' ? 4 : 20;
+  const precipMax = mode === 'hourly' ? 5 : 20;
 
   Chart.defaults.color = textColor;
   Chart.defaults.scale.grid.color = dividerColor;
@@ -18368,12 +18368,12 @@ renderMain({ config, sun, weather, temperature, feels_like, description } = this
   if (config.show_main === false)
     return x``;
 
-const use12HourFormat = config.use_12hour_format;
-const timeOptions = {
+  const use12HourFormat = config.use_12hour_format;
+  const timeOptions = {
     hour12: use12HourFormat,
     hour: 'numeric',
     minute: 'numeric'
-};
+  };
 
   const currentDate = new Date();
   const currentTime = currentDate.toLocaleTimeString(this.language, timeOptions);
@@ -18387,6 +18387,16 @@ const timeOptions = {
   const showCurrentCondition = config.show_current_condition !== false;
   const showTemperature = config.show_temperature !== false;
 
+  let roundedTemperature = temperature;
+  if (Number.isFinite(temperature) && temperature % 1 !== 0) {
+    roundedTemperature = Math.round(temperature * 10) / 10;
+  }
+
+  let roundedFeelsLike = feels_like;
+  if (Number.isFinite(feels_like) && feels_like % 1 !== 0) {
+    roundedFeelsLike = Math.round(feels_like * 10) / 10;
+  }
+
   const iconHtml = config.animated_icons || config.icons
     ? x`<img src="${this.getWeatherIcon(weather.state, sun.state)}" alt="">`
     : x`<ha-icon icon="${this.getWeatherIcon(weather.state, sun.state)}"></ha-icon>`;
@@ -18396,11 +18406,11 @@ const timeOptions = {
       ${iconHtml}
       <div>
         <div>
-          ${showTemperature ? x`${temperature}<span>${this.getUnit('temperature')}</span>` : ''}
-          ${showFeelsLike && feels_like ? x`
+          ${showTemperature ? x`${roundedTemperature}<span>${this.getUnit('temperature')}</span>` : ''}
+          ${showFeelsLike && roundedFeelsLike ? x`
             <div class="feels-like">
               ${this.ll('feelsLike')}
-              ${feels_like}${this.getUnit('temperature')}
+              ${roundedFeelsLike}${this.getUnit('temperature')}
             </div>
           ` : ''}
           ${showCurrentCondition ? x`

--- a/dist/weather-chart-card.js
+++ b/dist/weather-chart-card.js
@@ -17964,6 +17964,7 @@ drawChart({ config, language, weather, forecastItems } = this) {
   }
 
   const ctx = canvas.getContext('2d');
+  const precipMax = mode === 'hourly' ? 4 : 20;
 
   Chart.defaults.color = textColor;
   Chart.defaults.scale.grid.color = dividerColor;
@@ -18117,7 +18118,7 @@ drawChart({ config, language, weather, forecastItems } = this) {
         },
         PrecipAxis: {
           position: 'right',
-          suggestedMax: lengthUnit === 'km' ? 20 : 1,
+          suggestedMax: precipMax,
           grid: {
             display: false,
             drawTicks: false,

--- a/dist/weather-chart-card.js
+++ b/dist/weather-chart-card.js
@@ -17670,7 +17670,7 @@ setConfig(config) {
 
 set hass(hass) {
   this._hass = hass;
-  this.language = hass.selectedLanguage || hass.language;
+  this.language = this.config.locale || hass.selectedLanguage || hass.language;
   this.sun = 'sun.sun' in hass.states ? hass.states['sun.sun'] : null;
   this.unitSpeed = this.config.units.speed ? this.config.units.speed : this.weather && this.weather.attributes.wind_speed_unit;
   this.unitPressure = this.config.units.pressure ? this.config.units.pressure : this.weather && this.weather.attributes.pressure_unit;

--- a/dist/weather-chart-card.js
+++ b/dist/weather-chart-card.js
@@ -1210,6 +1210,15 @@ class WeatherCardEditor extends s {
               Show Wind Speed
             </label>
 	  </div>
+          <div class="switch-container">
+            <ha-switch
+              @change="${(e) => this._valueChanged(e, 'use_12hour_format')}"
+              .checked="${this._config.use_12hour_format !== false}"
+            ></ha-switch>
+            <label class="switch-label">
+              Use 12-Hour Format
+            </label>
+          </div>
           <div class="time-container">
             <div class="switch-right">
               <ha-switch
@@ -1351,15 +1360,6 @@ class WeatherCardEditor extends s {
             ></ha-switch>
             <label class="switch-label">
               Rounding Temperatures
-            </label>
-          </div>
-          <div class="switch-container">
-            <ha-switch
-              @change="${(e) => this._valueChanged(e, 'forecast.use_12hour_format')}"
-              .checked="${forecastConfig.use_12hour_format !== false}"
-            ></ha-switch>
-            <label class="switch-label">
-              Use 12-Hour Format
             </label>
           </div>
 	  <div class="textfield-container">
@@ -17590,6 +17590,7 @@ static getStubConfig(hass, unusedEntities, allEntities) {
     show_wind_speed: true,
     show_sun: true,
     show_feels_like: false,
+    use_12hour_format: false,
     icons_size: 25,
     animated_icons: false,
     icon_style: 'style1',
@@ -17602,7 +17603,6 @@ static getStubConfig(hass, unusedEntities, allEntities) {
       condition_icons: true,
       round_temp: false,
       type: 'daily',
-      use_12hour_format: false,
     },
   };
 }
@@ -17666,7 +17666,6 @@ setConfig(config) {
     throw new Error('Please, define entity in the card config');
   }
 }
-
 
 set hass(hass) {
   this._hass = hass;
@@ -18088,9 +18087,9 @@ drawChart({ config, language, weather, forecastItems } = this) {
               var weekday = dateObj.toLocaleString(language, { weekday: 'short' }).toUpperCase();
 
               var timeFormatOptions = {
-                hour12: config.forecast.use_12hour_format,
+                hour12: config.use_12hour_format,
                 hour: 'numeric',
-                ...(config.forecast.use_12hour_format ? {} : { minute: 'numeric' }),
+                ...(config.use_12hour_format ? {} : { minute: 'numeric' }),
               };
 
               var time = dateObj.toLocaleTimeString(language, timeFormatOptions);
@@ -18159,7 +18158,7 @@ drawChart({ config, language, weather, forecastItems } = this) {
                 weekday: 'short',
                 hour: 'numeric',
                 minute: 'numeric',
-		hour12: config.forecast.use_12hour_format,
+		hour12: config.use_12hour_format,
               });
             },
             label: function (context) {
@@ -18368,8 +18367,15 @@ renderMain({ config, sun, weather, temperature, feels_like, description } = this
   if (config.show_main === false)
     return x``;
 
+const use12HourFormat = config.use_12hour_format;
+const timeOptions = {
+    hour12: use12HourFormat,
+    hour: 'numeric',
+    minute: 'numeric'
+};
+
   const currentDate = new Date();
-  const currentTime = currentDate.toLocaleTimeString(this.language, { hour: 'numeric', minute: 'numeric' });
+  const currentTime = currentDate.toLocaleTimeString(this.language, timeOptions);
   const currentDayOfWeek = currentDate.toLocaleString(this.language, { weekday: 'short' }).toUpperCase();
   const currentDateFormatted = currentDate.toLocaleDateString(this.language, { month: 'short', day: 'numeric' });
   const showTime = config.show_time;
@@ -18527,15 +18533,23 @@ renderAttributes({ config, humidity, pressure, windSpeed, windDirection, sun, la
   `;
 }
 
-renderSun({ sun, language } = this) {
+renderSun({ sun, language, config } = this) {
   if (sun == undefined) {
     return x``;
   }
+
+const use12HourFormat = this.config.use_12hour_format;
+const timeOptions = {
+    hour12: use12HourFormat,
+    hour: 'numeric',
+    minute: 'numeric'
+};
+
   return x`
     <ha-icon icon="mdi:weather-sunset-up"></ha-icon>
-      ${new Date(sun.attributes.next_rising).toLocaleTimeString(language, { hour: '2-digit', minute: '2-digit' })}<br>
+      ${new Date(sun.attributes.next_rising).toLocaleTimeString(language, timeOptions)}<br>
     <ha-icon icon="mdi:weather-sunset-down"></ha-icon>
-      ${new Date(sun.attributes.next_setting).toLocaleTimeString(language, { hour: '2-digit', minute: '2-digit' })}
+      ${new Date(sun.attributes.next_setting).toLocaleTimeString(language, timeOptions)}
   `;
 }
 

--- a/dist/weather-chart-card.js
+++ b/dist/weather-chart-card.js
@@ -681,6 +681,40 @@ const locale = {
     'windy': 'Ventós',
     'windy-variant': 'Ràfegues de vent'
   },
+  ro: {
+    'tempHi': 'Temperatură',
+    'tempLo': 'Temperatură noaptea',
+    'precip': 'Precipitații',
+    'feelsLike': 'Se simte ca',
+    'units': {
+      'km/h': 'km/h',
+      'm/s': 'm/s',
+      'mph': 'mph',
+      'Bft': 'Bft',
+      'hPa': 'hPa',
+      'mmHg': 'mm Hg',
+      'mm': 'mm',
+      'in': 'in'
+    },
+    'cardinalDirections': [
+      'N', 'N-NE', 'NE', 'E-NE', 'E', 'E-SE', 'SE', 'S-SE',
+      'S', 'S-SV', 'SV', 'V-SV', 'V', 'V-NV', 'NV', 'N-NV', 'N'
+    ],
+    'clear-night': 'Cer senin, noapte',
+    'cloudy': 'Noros',
+    'fog': 'Ceață',
+    'hail': 'Grindină',
+    'lightning': 'Fulger',
+    'lightning-rainy': 'Fulger, ploios',
+    'partlycloudy': 'Parțial noros',
+    'pouring': 'Plouă torențial',
+    'rainy': 'Ploios',
+    'snowy': 'Ninge',
+    'snowy-rainy': 'Ninge, ploios',
+    'sunny': 'Însorit',
+    'windy': 'Vânt',
+    'windy-variant': 'Vânt'
+  },
 };
 
 const cardinalDirectionsIcon = [
@@ -1325,6 +1359,7 @@ class WeatherCardEditor extends s {
            <ha-list-item .value=${'no'}>Norwegian</ha-list-item>
            <ha-list-item .value=${'pl'}>Polish</ha-list-item>
            <ha-list-item .value=${'pt'}>Portuguese</ha-list-item>
+           <ha-list-item .value=${'ro'}>Romanian</ha-list-item>
            <ha-list-item .value=${'ru'}>Russian</ha-list-item>
            <ha-list-item .value=${'sk'}>Slovak</ha-list-item>
            <ha-list-item .value=${'es'}>Spanish</ha-list-item>

--- a/src/locale.js
+++ b/src/locale.js
@@ -679,6 +679,40 @@ const locale = {
     'windy': 'Ventós',
     'windy-variant': 'Ràfegues de vent'
   },
+  ro: {
+    'tempHi': 'Temperatură',
+    'tempLo': 'Temperatură noaptea',
+    'precip': 'Precipitații',
+    'feelsLike': 'Se simte ca',
+    'units': {
+      'km/h': 'km/h',
+      'm/s': 'm/s',
+      'mph': 'mph',
+      'Bft': 'Bft',
+      'hPa': 'hPa',
+      'mmHg': 'mm Hg',
+      'mm': 'mm',
+      'in': 'in'
+    },
+    'cardinalDirections': [
+      'N', 'N-NE', 'NE', 'E-NE', 'E', 'E-SE', 'SE', 'S-SE',
+      'S', 'S-SV', 'SV', 'V-SV', 'V', 'V-NV', 'NV', 'N-NV', 'N'
+    ],
+    'clear-night': 'Cer senin, noapte',
+    'cloudy': 'Noros',
+    'fog': 'Ceață',
+    'hail': 'Grindină',
+    'lightning': 'Fulger',
+    'lightning-rainy': 'Fulger, ploios',
+    'partlycloudy': 'Parțial noros',
+    'pouring': 'Plouă torențial',
+    'rainy': 'Ploios',
+    'snowy': 'Ninge',
+    'snowy-rainy': 'Ninge, ploios',
+    'sunny': 'Însorit',
+    'windy': 'Vânt',
+    'windy-variant': 'Vânt'
+  },
 };
 
 export default locale;

--- a/src/main.js
+++ b/src/main.js
@@ -413,6 +413,7 @@ drawChart({ config, language, weather, forecastItems } = this) {
   }
 
   const ctx = canvas.getContext('2d');
+  const precipMax = mode === 'hourly' ? 5 : 20;
 
   Chart.defaults.color = textColor;
   Chart.defaults.scale.grid.color = dividerColor;
@@ -566,7 +567,7 @@ drawChart({ config, language, weather, forecastItems } = this) {
         },
         PrecipAxis: {
           position: 'right',
-          suggestedMax: lengthUnit === 'km' ? 20 : 1,
+          suggestedMax: precipMax,
           grid: {
             display: false,
             drawTicks: false,

--- a/src/main.js
+++ b/src/main.js
@@ -817,12 +817,12 @@ renderMain({ config, sun, weather, temperature, feels_like, description } = this
   if (config.show_main === false)
     return html``;
 
-const use12HourFormat = config.use_12hour_format;
-const timeOptions = {
+  const use12HourFormat = config.use_12hour_format;
+  const timeOptions = {
     hour12: use12HourFormat,
     hour: 'numeric',
     minute: 'numeric'
-};
+  };
 
   const currentDate = new Date();
   const currentTime = currentDate.toLocaleTimeString(this.language, timeOptions);
@@ -836,6 +836,16 @@ const timeOptions = {
   const showCurrentCondition = config.show_current_condition !== false;
   const showTemperature = config.show_temperature !== false;
 
+  let roundedTemperature = temperature;
+  if (Number.isFinite(temperature) && temperature % 1 !== 0) {
+    roundedTemperature = Math.round(temperature * 10) / 10;
+  }
+
+  let roundedFeelsLike = feels_like;
+  if (Number.isFinite(feels_like) && feels_like % 1 !== 0) {
+    roundedFeelsLike = Math.round(feels_like * 10) / 10;
+  }
+
   const iconHtml = config.animated_icons || config.icons
     ? html`<img src="${this.getWeatherIcon(weather.state, sun.state)}" alt="">`
     : html`<ha-icon icon="${this.getWeatherIcon(weather.state, sun.state)}"></ha-icon>`;
@@ -845,11 +855,11 @@ const timeOptions = {
       ${iconHtml}
       <div>
         <div>
-          ${showTemperature ? html`${temperature}<span>${this.getUnit('temperature')}</span>` : ''}
-          ${showFeelsLike && feels_like ? html`
+          ${showTemperature ? html`${roundedTemperature}<span>${this.getUnit('temperature')}</span>` : ''}
+          ${showFeelsLike && roundedFeelsLike ? html`
             <div class="feels-like">
               ${this.ll('feelsLike')}
-              ${feels_like}${this.getUnit('temperature')}
+              ${roundedFeelsLike}${this.getUnit('temperature')}
             </div>
           ` : ''}
           ${showCurrentCondition ? html`

--- a/src/main.js
+++ b/src/main.js
@@ -184,6 +184,9 @@ subscribeForecastEvents() {
 
   constructor() {
     super();
+    window.addEventListener('orientationchange', () => {
+      this.measureCard();
+    });
   }
 
 ll(str) {

--- a/src/main.js
+++ b/src/main.js
@@ -119,7 +119,7 @@ setConfig(config) {
 
 set hass(hass) {
   this._hass = hass;
-  this.language = hass.selectedLanguage || hass.language;
+  this.language = this.config.locale || hass.selectedLanguage || hass.language;
   this.sun = 'sun.sun' in hass.states ? hass.states['sun.sun'] : null;
   this.unitSpeed = this.config.units.speed ? this.config.units.speed : this.weather && this.weather.attributes.wind_speed_unit;
   this.unitPressure = this.config.units.pressure ? this.config.units.pressure : this.weather && this.weather.attributes.pressure_unit;

--- a/src/main.js
+++ b/src/main.js
@@ -39,6 +39,7 @@ static getStubConfig(hass, unusedEntities, allEntities) {
     show_wind_speed: true,
     show_sun: true,
     show_feels_like: false,
+    use_12hour_format: false,
     icons_size: 25,
     animated_icons: false,
     icon_style: 'style1',
@@ -51,7 +52,6 @@ static getStubConfig(hass, unusedEntities, allEntities) {
       condition_icons: true,
       round_temp: false,
       type: 'daily',
-      use_12hour_format: false,
     },
   };
 }
@@ -115,7 +115,6 @@ setConfig(config) {
     throw new Error('Please, define entity in the card config');
   }
 }
-
 
 set hass(hass) {
   this._hass = hass;
@@ -537,9 +536,9 @@ drawChart({ config, language, weather, forecastItems } = this) {
               var weekday = dateObj.toLocaleString(language, { weekday: 'short' }).toUpperCase();
 
               var timeFormatOptions = {
-                hour12: config.forecast.use_12hour_format,
+                hour12: config.use_12hour_format,
                 hour: 'numeric',
-                ...(config.forecast.use_12hour_format ? {} : { minute: 'numeric' }),
+                ...(config.use_12hour_format ? {} : { minute: 'numeric' }),
               };
 
               var time = dateObj.toLocaleTimeString(language, timeFormatOptions);
@@ -608,7 +607,7 @@ drawChart({ config, language, weather, forecastItems } = this) {
                 weekday: 'short',
                 hour: 'numeric',
                 minute: 'numeric',
-		hour12: config.forecast.use_12hour_format,
+		hour12: config.use_12hour_format,
               });
             },
             label: function (context) {
@@ -817,8 +816,15 @@ renderMain({ config, sun, weather, temperature, feels_like, description } = this
   if (config.show_main === false)
     return html``;
 
+const use12HourFormat = config.use_12hour_format;
+const timeOptions = {
+    hour12: use12HourFormat,
+    hour: 'numeric',
+    minute: 'numeric'
+};
+
   const currentDate = new Date();
-  const currentTime = currentDate.toLocaleTimeString(this.language, { hour: 'numeric', minute: 'numeric' });
+  const currentTime = currentDate.toLocaleTimeString(this.language, timeOptions);
   const currentDayOfWeek = currentDate.toLocaleString(this.language, { weekday: 'short' }).toUpperCase();
   const currentDateFormatted = currentDate.toLocaleDateString(this.language, { month: 'short', day: 'numeric' });
   const showTime = config.show_time;
@@ -976,15 +982,23 @@ renderAttributes({ config, humidity, pressure, windSpeed, windDirection, sun, la
   `;
 }
 
-renderSun({ sun, language } = this) {
+renderSun({ sun, language, config } = this) {
   if (sun == undefined) {
     return html``;
   }
+
+const use12HourFormat = this.config.use_12hour_format;
+const timeOptions = {
+    hour12: use12HourFormat,
+    hour: 'numeric',
+    minute: 'numeric'
+};
+
   return html`
     <ha-icon icon="mdi:weather-sunset-up"></ha-icon>
-      ${new Date(sun.attributes.next_rising).toLocaleTimeString(language, { hour: '2-digit', minute: '2-digit' })}<br>
+      ${new Date(sun.attributes.next_rising).toLocaleTimeString(language, timeOptions)}<br>
     <ha-icon icon="mdi:weather-sunset-down"></ha-icon>
-      ${new Date(sun.attributes.next_setting).toLocaleTimeString(language, { hour: '2-digit', minute: '2-digit' })}
+      ${new Date(sun.attributes.next_setting).toLocaleTimeString(language, timeOptions)}
   `;
 }
 

--- a/src/weather-card-editor.js
+++ b/src/weather-card-editor.js
@@ -562,6 +562,7 @@ class WeatherCardEditor extends LitElement {
            <ha-list-item .value=${'no'}>Norwegian</ha-list-item>
            <ha-list-item .value=${'pl'}>Polish</ha-list-item>
            <ha-list-item .value=${'pt'}>Portuguese</ha-list-item>
+           <ha-list-item .value=${'ro'}>Romanian</ha-list-item>
            <ha-list-item .value=${'ru'}>Russian</ha-list-item>
            <ha-list-item .value=${'sk'}>Slovak</ha-list-item>
            <ha-list-item .value=${'es'}>Spanish</ha-list-item>

--- a/src/weather-card-editor.js
+++ b/src/weather-card-editor.js
@@ -447,6 +447,15 @@ class WeatherCardEditor extends LitElement {
               Show Wind Speed
             </label>
 	  </div>
+          <div class="switch-container">
+            <ha-switch
+              @change="${(e) => this._valueChanged(e, 'use_12hour_format')}"
+              .checked="${this._config.use_12hour_format !== false}"
+            ></ha-switch>
+            <label class="switch-label">
+              Use 12-Hour Format
+            </label>
+          </div>
           <div class="time-container">
             <div class="switch-right">
               <ha-switch
@@ -588,15 +597,6 @@ class WeatherCardEditor extends LitElement {
             ></ha-switch>
             <label class="switch-label">
               Rounding Temperatures
-            </label>
-          </div>
-          <div class="switch-container">
-            <ha-switch
-              @change="${(e) => this._valueChanged(e, 'forecast.use_12hour_format')}"
-              .checked="${forecastConfig.use_12hour_format !== false}"
-            ></ha-switch>
-            <label class="switch-label">
-              Use 12-Hour Format
             </label>
           </div>
 	  <div class="textfield-container">


### PR DESCRIPTION
## **⚠️ Breaking Changes**
- use_12hour_format setting is moved from forecast to global, if used, please update your yml code

### **🚀 Features**
- Added Romanian Translation
- Made use_12hour_format global (Closes #85 & Closes #97)
- Locale setting now applies to full card (Closes #85 & Closes #97)

### **🛠 Under the hood**
- Adjusted precipitation bars height for hourly type (Closes #96)
- Round temperature and feels-like to one decimal place (Closes #81)
- Add auto-refresh functionality on screen rotation (#68)