### PR TITLE
Add autoscroll configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ HACS is a third party community store and is not included in Home Assistant out 
 | forecast              | object  | none                     | See [forecast options](#forecast-options) for available options.                                   |
 | units                 | object  | none                     | See [units of measurement](#units-of-measurement) for available options.                           |
 | locale                | string  | none                     | See [Supported languages](#Supported-languages) for available languages                            |
+| autoscroll            | boolean | false                    | Update the chart each hour, hiding prior forecast datapoints                                       |
 
 ##### Forecast options
 

--- a/src/main.js
+++ b/src/main.js
@@ -431,17 +431,6 @@ drawChart({ config, language, weather, forecastItems } = this) {
     var precipUnit = lengthUnit === 'km' ? this.ll('units')['mm'] : this.ll('units')['in'];
   }
   var forecast = this.forecasts ? this.forecasts.slice(0, forecastItems) : [];
-  if (forecast.length >= 3) {
-    var date1 = new Date(forecast[1].datetime).toISOString().split('T')[0];
-    var date2 = new Date(forecast[2].datetime).toISOString().split('T')[0];
-    if (date1 !== date2) {
-      var mode = 'daily';
-    } else {
-      var mode = 'hourly';
-    }
-  } else {
-    console.log("Insufficient forecast data.");
-  }
   var roundTemp = config.forecast.round_temp == true;
   var i;
   var dateTime = [];
@@ -484,7 +473,7 @@ drawChart({ config, language, weather, forecastItems } = this) {
   if (config.forecast.precipitation_type === 'probability') {
     precipMax = 100;
   } else {
-    if (mode === 'hourly') {
+    if (config.forecast.type === 'hourly') {
       precipMax = lengthUnit === 'km' ? 4 : 1;
     } else {
       precipMax = lengthUnit === 'km' ? 20 : 1;
@@ -637,7 +626,7 @@ drawChart({ config, language, weather, forecastItems } = this) {
 
                   var time = dateObj.toLocaleTimeString(language, timeFormatOptions);
 
-                  if (dateObj.getHours() === 0 && dateObj.getMinutes() === 0 && mode === 'hourly') {
+                  if (dateObj.getHours() === 0 && dateObj.getMinutes() === 0 && config.forecast.type === 'hourly') {
                       var dateFormatOptions = {
                           day: 'numeric',
                           month: 'short',
@@ -647,7 +636,7 @@ drawChart({ config, language, weather, forecastItems } = this) {
                       return [date, time];
                   }
 
-                  if (mode !== 'hourly') {
+                  if (config.forecast.type !== 'hourly') {
                       var weekday = dateObj.toLocaleString(language, { weekday: 'short' }).toUpperCase();
                       return weekday;
                   }

--- a/src/weather-chart-card-editor.js
+++ b/src/weather-chart-card-editor.js
@@ -519,6 +519,15 @@ class WeatherChartCardEditor extends LitElement {
               Use 12-Hour Format
             </label>
           </div>
+          <div class="switch-container">
+            <ha-switch
+              @change="${(e) => this._valueChanged(e, 'autoscroll')}"
+              .checked="${this._config.autoscroll !== false}"
+            ></ha-switch>
+            <label class="switch-label">
+              Autoscroll
+            </label>
+          </div>
           <div class="time-container">
             <div class="switch-right">
               <ha-switch


### PR DESCRIPTION
- Fixes an issue I noticed where if you load the chart at the wrong time, an hourly chart has labels with days instead.

- Addresses #170 by adding a new "Autoscroll" option that updates the chart every hour and discards outdated datapoints (oudated being more than an hour old for daily charts, and more than a day old for daily charts). This allows the chart to be left up (like on a wall mounted tablet) and the left side always shows the current hour/day's forecast.

This is my first time tying to contribute to any kind of HACS component, so lmk if I'm missing anything for adding a new config option.

Also open to suggestions for naming the config option, I was also considering 'hideOutdatedData'.