### PR TITLE
precipitation display changes; forecast style3

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,10 @@ HACS is a third party community store and is not included in Home Assistant out 
 | Name                 | Type    | Default                  | Description                                                                                        |
 | -------------------- | ------- | -------------------------|--------------------------------------------------------------------------------------------------- |
 | precipitation_type   | string  | rainfall                 | Show precipitation in 'rainfall' or 'probability'.                                                 |
-| show_probability     | boolean | false                    | Also show probability value when precipitation_type = rainfall. (Only when available)              |
-| labels_font_size     | number  | 11                       | Font size for temperature and precipitation labels.                                                |
+| show_probability     | boolean | false                    | Show probability value on precipitation label when available.              |
+| show_rainfall        | boolean | false                    | Show rainfall value on precipitation label when available |
+| labels_font_size     | number  | 11                       | Font size for temperature labels.                                                |
+| precip_labels_font_size  | number  | 10                   | Font size for precipitation labels. |
 | precip_bar_size      | number  | 100                      | Adjusts the thickness of precipitation bars (1-100).                                               |
 | temperature1_color   | string  | rgba(255, 152, 0, 1.0)   | Temperature first line chart color.                                                                |
 | temperature2_color   | string  | rgba(68, 115, 158, 1.0)  | Temperature second line chart color.                                                               |
@@ -88,10 +90,11 @@ HACS is a third party community store and is not included in Home Assistant out 
 | condition_icons      | boolean | true                     | Show or hide forecast condition icons.                                                             |
 | show_wind_forecast   | boolean | true                     | Show or hide wind forecast on the card.                                                            |
 | round_temp           | boolean | false                    | Option for rounding the forecast temperatures                                                      |
-| style                | string  | style1                   | Change chart style, options: 'style1' or 'style2'                                                  |
+| style                | string  | style1                   | Change chart style, options: 'style1', 'style2' or 'style3'                       |
 | type                 | string  | daily                    | Show daily or hourly forecast if available, options: 'daily' or 'hourly'                           |
 | number_of_forecasts  | number  | 0                        | Overrides the number of forecasts to display. Set to "0" for automatic mode.                       |
 | disable_animation    | boolean | false                    | Disable the chart animation.                                                                       |
+| disable_tooltips     | boolean | false                    | Disable chart tooltips.  |
 
 ##### Units of measurement
 

--- a/src/weather-chart-card-editor.js
+++ b/src/weather-chart-card-editor.js
@@ -221,7 +221,7 @@ class WeatherChartCardEditor extends LitElement {
           margin-bottom: 12px;
         }
         .page-container {
-	  display: none;
+          display: none;
         }
         .page-container.active {
           display: block;
@@ -250,7 +250,7 @@ class WeatherChartCardEditor extends LitElement {
           display: flex;
           flex-direction: column;
           margin-bottom: 10px;
-	  gap: 20px;
+          gap: 20px;
         }
         .radio-container {
           display: flex;
@@ -264,7 +264,7 @@ class WeatherChartCardEditor extends LitElement {
         .radio-group label {
           margin-left: 4px;
         }
-	div.buttons-container {
+        div.buttons-container {
           border-bottom: 2px solid #ccc;
           padding-bottom: 10px;
           margin-bottom: 20px;
@@ -350,6 +350,18 @@ class WeatherChartCardEditor extends LitElement {
           ></ha-radio>
           <label class="check-label">
             Chart style 2
+          </label>
+        </div>
+
+        <div class="switch-right">
+          <ha-radio
+            name="style"
+            value="style3"
+            @change="${this._handleStyleChange}"
+            .checked="${forecastConfig.style === 'style3'}"
+          ></ha-radio>
+          <label class="check-label">
+            Chart style 3
           </label>
         </div>
       </div>
@@ -467,7 +479,7 @@ class WeatherChartCardEditor extends LitElement {
             <label class="switch-label">
               Show Wind Speed
             </label>
-	  </div>
+    </div>
       <div class="switch-container">
         ${this.hasDewpoint ? html`
           <ha-switch
@@ -662,8 +674,8 @@ class WeatherChartCardEditor extends LitElement {
            <ha-list-item .value=${'sk'}>Slovak</ha-list-item>
            <ha-list-item .value=${'es'}>Spanish</ha-list-item>
            <ha-list-item .value=${'sv'}>Swedish</ha-list-item>
-	   <ha-list-item .value=${'uk'}>Ukrainian</ha-list-item>
-    	   <ha-list-item .value=${'ko'}>한국어</ha-list-item>
+           <ha-list-item .value=${'uk'}>Ukrainian</ha-list-item>
+           <ha-list-item .value=${'ko'}>한국어</ha-list-item>
         </ha-select>
         </div>
       </div>
@@ -706,7 +718,16 @@ class WeatherChartCardEditor extends LitElement {
               Disable Chart Animation
             </label>
           </div>
-	  <div class="textfield-container">
+          <div class="switch-container">
+            <ha-switch
+              @change="${(e) => this._valueChanged(e, 'forecast.disable_tooltips')}"
+              .checked="${forecastConfig.disable_tooltips !== false}"
+            ></ha-switch>
+            <label class="switch-label">
+              Disable Chart Tooltips
+            </label>
+          </div>
+          <div class="textfield-container">
           <ha-select
             naturalMenuWidth
             fixedMenuPosition
@@ -719,15 +740,25 @@ class WeatherChartCardEditor extends LitElement {
             <ha-list-item .value=${'rainfall'}>Rainfall</ha-list-item>
             <ha-list-item .value=${'probability'}>Probability</ha-list-item>
           </ha-select>
-         <div class="switch-container" ?hidden=${forecastConfig.precipitation_type !== 'rainfall'}>
-             <ha-switch
-               @change="${(e) => this._valueChanged(e, 'forecast.show_probability')}"
-               .checked="${forecastConfig.show_probability !== false}"
-             ></ha-switch>
-             <label class="switch-label">
-               Show precipitation probability
-             </label>
-         </div>
+          </div>
+          <div class="switch-container">
+            <ha-switch
+              @change="${(e) => this._valueChanged(e, 'forecast.show_probability')}"
+              .checked="${forecastConfig.show_probability !== false}"
+            ></ha-switch>
+            <label class="switch-label">
+              Show precipitation probability
+            </label>
+          </div>
+          <div class="switch-container">
+            <ha-switch
+              @change="${(e) => this._valueChanged(e, 'forecast.show_rainfall')}"
+              .checked="${forecastConfig.show_rainfall !== false}"
+            ></ha-switch>
+            <label class="switch-label">
+              Show rainfall
+            </label>
+          </div>
           <div class="textfield-container">
             <div class="flex-container">
               <ha-textfield
@@ -744,8 +775,8 @@ class WeatherChartCardEditor extends LitElement {
                 .value="${forecastConfig.labels_font_size || '11'}"
                 @change="${(e) => this._valueChanged(e, 'forecast.labels_font_size')}"
               ></ha-textfield>
-              </div>
-	    <div class="flex-container">
+            </div>
+            <div class="flex-container">
               <ha-textfield
                 label="Chart height"
                 type="number"
@@ -753,12 +784,19 @@ class WeatherChartCardEditor extends LitElement {
                 @change="${(e) => this._valueChanged(e, 'forecast.chart_height')}"
               ></ha-textfield>
               <ha-textfield
+                label="Precipitation Labels Font Size"
+                type="number"
+                .value="${forecastConfig.precip_labels_font_size || '10'}"
+                @change="${(e) => this._valueChanged(e, 'forecast.precip_labels_font_size')}"
+              ></ha-textfield>
+            </div>
+            <div class="flex-container">
+              <ha-textfield
                 label="Number of forecasts"
                 type="number"
                 .value="${forecastConfig.number_of_forecasts || '0'}"
                 @change="${(e) => this._valueChanged(e, 'forecast.number_of_forecasts')}"
               ></ha-textfield>
-              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Features:
- option to show or hide rainfall value on the precipitation label #178
- option to show or hide precipitation probability value on the precipitation label #178
- don't show precipitation label if both options from above are off #178
- precipitation type now only affects precipitation bar #178
- option to change precipitation label font size
- option to completely disable graph tooltips
- add `style3` forecast chart style, with rounded temperature and precipitation label borders
![192 168 1 2_8123_lovelace_default_view](https://github.com/user-attachments/assets/c638cd21-f7ce-4795-948e-9141bae2ee45)
