### PR TITLE
Rename `visibility` custom entity configuration to `visibility_entity`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ HACS is a third party community store and is not included in Home Assistant out 
 | feels_like            | string  | none                     | An entity_id for a custom feels like temperature sensor.                                           |
 | dew_point             | string  | none                     | An entity_id for a custom dew point sensor.                                                        |
 | wind_gust_speed       | string  | none                     | An entity_id for a custom wind gust speed sensor.                                                  |
-| visibility            | string  | none                     | An entity_id for a custom visibility sensor.                                                       |
+| visibility_entity            | string  | none                     | An entity_id for a custom visibility sensor.                                                       |
 | description           | string  | none                     | An entity_id for a custom weather description sensor.                                              |
 | title                 | string  | none                     | Card title.                                                                                        |
 | show_main             | boolean | true                     | Show or hide a section with current weather condition and temperature.                             |

--- a/README.md
+++ b/README.md
@@ -23,53 +23,53 @@ HACS is a third party community store and is not included in Home Assistant out 
 
 ##### Card options
 
-| Name                  | Type    | Default                  | Description                                                                                        |
-| ----------------------| ------- | -------------------------|--------------------------------------------------------------------------------------------------- |
-| type                  | string  | **Required**             | Should be `custom:weather-chart-card`.                                                             |
-| entity                | string  | **Required**             | An entity_id with the `weather` domain.                                                            |
-| temp                  | string  | none                     | An entity_id for a custom temperature sensor.                                                      |
-| press                 | string  | none                     | An entity_id for a custom pressure sensor.                                                         |
-| humid                 | string  | none                     | An entity_id for a custom humidity sensor.                                                         |
-| uv                    | string  | none                     | An entity_id for a custom UV index sensor.                                                         |
-| winddir               | string  | none                     | An entity_id for a custom wind bearing sensor. Sensor should have value in degrees                 |
-| windspeed             | string  | none                     | An entity_id for a custom wind speed sensor.                                                       |
-| feels_like            | string  | none                     | An entity_id for a custom feels like temperature sensor.                                           |
-| dew_point             | string  | none                     | An entity_id for a custom dew point sensor.                                                        |
-| wind_gust_speed       | string  | none                     | An entity_id for a custom wind gust speed sensor.                                                  |
-| visibility_entity            | string  | none                     | An entity_id for a custom visibility sensor.                                                       |
-| description           | string  | none                     | An entity_id for a custom weather description sensor.                                              |
-| title                 | string  | none                     | Card title.                                                                                        |
-| show_main             | boolean | true                     | Show or hide a section with current weather condition and temperature.                             |
-| show_temperature      | boolean | true                     | Show or hide the current temperature.                                                              |
-| show_current_condition| boolean | true                     | Show or hide the current weather condition.                                                        |
-| show_attributes       | boolean | true                     | Show or hide a section with attributes such as pressure, humidity, wind direction and speed, etc.  |
-| show_sun              | boolean | true                     | Show or hide the sunset information                                                                |
-| show_time             | boolean | false                    | Show or hide the current time on the card.                                                         |
-| show_time_seconds     | boolean | false                    | Show or hide seconds for the current time on the card.                                             |
-| show_day              | boolean | false                    | Show or hide the current day on the card. (Only visible when show_time is true.)                   |
-| show_date             | boolean | false                    | Show or hide the current date the card. (Only visible when show_time is true.)                     |
-| show_humidity         | boolean | true                     | Show or hide humidity on the card.                                                                 |
-| show_pressure         | boolean | true                     | Show or hide pressure on the card.                                                                 |
-| show_wind_direction   | boolean | true                     | Show or hide wind_direction on the card.                                                           |
-| show_wind_speed       | boolean | true                     | Show or hide wind_speed on the card.                                                               |
-| show_feels_like       | boolean | false                    | Show or hide feels like temperature on the card.                                                   |
-| show_dew_point        | boolean | false                    | Show or hide dew point on the card.                                                                |
-| show_wind_gust_speed  | boolean | false                    | Show or hide wind gust speed on the card.                                                          |
-| show_visibility       | boolean | false                    | Show or hide visibility on the card.                                                               |
-| show_description      | boolean | false                    | Show or hide the weather description on the card.                                                  |
-| show_last_changed     | boolean | false                    | Show or hide when last data changed on the card.                                                   |
-| use_12hour_format     | boolean | false                    | Display time in 12-hour format (AM/PM) instead of 24-hour format.                                  |
-| icons                 | string  | none                     | Path to the location of custom icons in svg format, for example `/local/weather-icons/`.           |
-| animated_icons        | boolean | false                    | Enable the use of animated icons                                                                   |
-| icon_style            | string  | 'style1'                 | Options are 'style1' and'style2' for different set of animated icons.                              |
-| icons_size            | number  | 25                       | The size of the animated or custom icons in pixels.                                                |
-| current_temp_size     | number  | 28                       | The size of the current temperature in pixels.                                                     |
-| time_size             | number  | 26                       | The size of the current time in pixels.                                                            |
-| day_date_size         | number  | 15                       | The size of the current day and date in pixels.                                                    |
-| forecast              | object  | none                     | See [forecast options](#forecast-options) for available options.                                   |
-| units                 | object  | none                     | See [units of measurement](#units-of-measurement) for available options.                           |
-| locale                | string  | none                     | See [Supported languages](#Supported-languages) for available languages                            |
-| autoscroll            | boolean | false                    | Update the chart each hour, hiding prior forecast datapoints                                       |
+| Name                   | Type    | Default                   | Description                                                                                         |
+| ---------------------- | ------- | ------------------------- | --------------------------------------------------------------------------------------------------- |
+| type                   | string  | **Required**              | Should be `custom:weather-chart-card`.                                                              |
+| entity                 | string  | **Required**              | An entity_id with the `weather` domain.                                                             |
+| temp                   | string  | none                      | An entity_id for a custom temperature sensor.                                                       |
+| press                  | string  | none                      | An entity_id for a custom pressure sensor.                                                          |
+| humid                  | string  | none                      | An entity_id for a custom humidity sensor.                                                          |
+| uv                     | string  | none                      | An entity_id for a custom UV index sensor.                                                          |
+| winddir                | string  | none                      | An entity_id for a custom wind bearing sensor. Sensor should have value in degrees                  |
+| windspeed              | string  | none                      | An entity_id for a custom wind speed sensor.                                                        |
+| feels_like             | string  | none                      | An entity_id for a custom feels like temperature sensor.                                            |
+| dew_point              | string  | none                      | An entity_id for a custom dew point sensor.                                                         |
+| wind_gust_speed        | string  | none                      | An entity_id for a custom wind gust speed sensor.                                                   |
+| visibility_entity      | string  | none                      | An entity_id for a custom visibility sensor.                                                        |
+| description            | string  | none                      | An entity_id for a custom weather description sensor.                                               |
+| title                  | string  | none                      | Card title.                                                                                         |
+| show_main              | boolean | true                      | Show or hide a section with current weather condition and temperature.                              |
+| show_temperature       | boolean | true                      | Show or hide the current temperature.                                                               |
+| show_current_condition | boolean | true                      | Show or hide the current weather condition.                                                         |
+| show_attributes        | boolean | true                      | Show or hide a section with attributes such as pressure, humidity, wind direction and speed, etc.   |
+| show_sun               | boolean | true                      | Show or hide the sunset information                                                                 |
+| show_time              | boolean | false                     | Show or hide the current time on the card.                                                          |
+| show_time_seconds      | boolean | false                     | Show or hide seconds for the current time on the card.                                              |
+| show_day               | boolean | false                     | Show or hide the current day on the card. (Only visible when show_time is true.)                    |
+| show_date              | boolean | false                     | Show or hide the current date the card. (Only visible when show_time is true.)                      |
+| show_humidity          | boolean | true                      | Show or hide humidity on the card.                                                                  |
+| show_pressure          | boolean | true                      | Show or hide pressure on the card.                                                                  |
+| show_wind_direction    | boolean | true                      | Show or hide wind_direction on the card.                                                            |
+| show_wind_speed        | boolean | true                      | Show or hide wind_speed on the card.                                                                |
+| show_feels_like        | boolean | false                     | Show or hide feels like temperature on the card.                                                    |
+| show_dew_point         | boolean | false                     | Show or hide dew point on the card.                                                                 |
+| show_wind_gust_speed   | boolean | false                     | Show or hide wind gust speed on the card.                                                           |
+| show_visibility        | boolean | false                     | Show or hide visibility on the card.                                                                |
+| show_description       | boolean | false                     | Show or hide the weather description on the card.                                                   |
+| show_last_changed      | boolean | false                     | Show or hide when last data changed on the card.                                                    |
+| use_12hour_format      | boolean | false                     | Display time in 12-hour format (AM/PM) instead of 24-hour format.                                   |
+| icons                  | string  | none                      | Path to the location of custom icons in svg format, for example `/local/weather-icons/`.            |
+| animated_icons         | boolean | false                     | Enable the use of animated icons                                                                    |
+| icon_style             | string  | 'style1'                  | Options are 'style1' and'style2' for different set of animated icons.                               |
+| icons_size             | number  | 25                        | The size of the animated or custom icons in pixels.                                                 |
+| current_temp_size      | number  | 28                        | The size of the current temperature in pixels.                                                      |
+| time_size              | number  | 26                        | The size of the current time in pixels.                                                             |
+| day_date_size          | number  | 15                        | The size of the current day and date in pixels.                                                     |
+| forecast               | object  | none                      | See [forecast options](#forecast-options) for available options.                                    |
+| units                  | object  | none                      | See [units of measurement](#units-of-measurement) for available options.                            |
+| locale                 | string  | none                      | See [Supported languages](#Supported-languages) for available languages                             |
+| autoscroll             | boolean | false                     | Update the chart each hour, hiding prior forecast datapoints                                        |
 
 ##### Forecast options
 

--- a/dist/weather-chart-card.js
+++ b/dist/weather-chart-card.js
@@ -68,7 +68,7 @@ const locale = {
     'sunny': 'Jasno',
     'windy': 'Veterno',
     'windy-variant': 'Veterno'
-  },  
+  },
   de: {
     'tempHi': 'Temperatur',
     'tempLo': 'Nachttemperatur',
@@ -876,7 +876,7 @@ const ALT_SCHEMA = [
   { name: "windspeed", title: "Alternative wind speed sensor", selector: { entity: { domain: 'sensor' } } },
   { name: "dew_point", title: "Alternative dew pointsensor", selector: { entity: { domain: 'sensor' } } },
   { name: "wind_gust_speed", title: "Alternative wind gust speed sensor", selector: { entity: { domain: 'sensor' } } },
-  { name: "visibility", title: "Alternative visibility sensor", selector: { entity: { domain: 'sensor' } } },
+  { name: "visibility_entity", title: "Alternative visibility sensor", selector: { entity: { domain: 'sensor' } } },
 ];
 
 class WeatherChartCardEditor extends s {
@@ -926,15 +926,15 @@ class WeatherChartCardEditor extends s {
       this.hass &&
       this.hass.states[config.entity] &&
       this.hass.states[config.entity].attributes &&
-      this.hass.states[config.entity].attributes.visibility !== undefined
-    ) || config.visibility !== undefined;
+      this.hass.states[config.entity].attributes.visibility_entity !== undefined
+    ) || config.visibility_entity !== undefined;
     this.hasDescription = (
       this.hass &&
       this.hass.states[config.entity] &&
       this.hass.states[config.entity].attributes &&
       this.hass.states[config.entity].attributes.description !== undefined
     ) || config.description !== undefined;
-    this.fetchEntities();	  
+    this.fetchEntities();
     this.requestUpdate();
   }
 
@@ -17834,8 +17834,8 @@ static getStubConfig(hass, unusedEntities, allEntities) {
       condition_icons: true,
       round_temp: false,
       type: 'daily',
-      number_of_forecasts: '0', 
-      disable_animation: false, 
+      number_of_forecasts: '0',
+      disable_animation: false,
     },
   };
 }
@@ -17928,7 +17928,7 @@ set hass(hass) {
     this.windSpeed = this.config.windspeed ? hass.states[this.config.windspeed].state : this.weather.attributes.wind_speed;
     this.dew_point = this.config.dew_point ? hass.states[this.config.dew_point].state : this.weather.attributes.dew_point;
     this.wind_gust_speed = this.config.wind_gust_speed ? hass.states[this.config.wind_gust_speed].state : this.weather.attributes.wind_gust_speed;
-    this.visibility = this.config.visibility ? hass.states[this.config.visibility].state : this.weather.attributes.visibility;
+    this.visibility = this.config.visibility_entity ? hass.states[this.config.visibility_entity].state : this.weather.attributes.visibility;
 
     if (this.config.winddir && hass.states[this.config.winddir] && hass.states[this.config.winddir].state !== undefined) {
       this.windDirection = parseFloat(hass.states[this.config.winddir].state);
@@ -18414,7 +18414,7 @@ drawChart({ config, language, weather, forecastItems } = this) {
               callback: function (value, index, values) {
                   var datetime = this.getLabelForValue(value);
                   var dateObj = new Date(datetime);
-        
+
                   var timeFormatOptions = {
                       hour12: config.use_12hour_format,
                       hour: 'numeric',

--- a/src/main.js
+++ b/src/main.js
@@ -59,8 +59,8 @@ static getStubConfig(hass, unusedEntities, allEntities) {
       condition_icons: true,
       round_temp: false,
       type: 'daily',
-      number_of_forecasts: '0', 
-      disable_animation: false, 
+      number_of_forecasts: '0',
+      disable_animation: false,
     },
   };
 }
@@ -153,7 +153,7 @@ set hass(hass) {
     this.windSpeed = this.config.windspeed ? hass.states[this.config.windspeed].state : this.weather.attributes.wind_speed;
     this.dew_point = this.config.dew_point ? hass.states[this.config.dew_point].state : this.weather.attributes.dew_point;
     this.wind_gust_speed = this.config.wind_gust_speed ? hass.states[this.config.wind_gust_speed].state : this.weather.attributes.wind_gust_speed;
-    this.visibility = this.config.visibility ? hass.states[this.config.visibility].state : this.weather.attributes.visibility;
+    this.visibility = this.config.visibility_entity ? hass.states[this.config.visibility_entity].state : this.weather.attributes.visibility;
 
     if (this.config.winddir && hass.states[this.config.winddir] && hass.states[this.config.winddir].state !== undefined) {
       this.windDirection = parseFloat(hass.states[this.config.winddir].state);
@@ -639,7 +639,7 @@ drawChart({ config, language, weather, forecastItems } = this) {
               callback: function (value, index, values) {
                   var datetime = this.getLabelForValue(value);
                   var dateObj = new Date(datetime);
-        
+
                   var timeFormatOptions = {
                       hour12: config.use_12hour_format,
                       hour: 'numeric',

--- a/src/weather-chart-card-editor.js
+++ b/src/weather-chart-card-editor.js
@@ -11,7 +11,7 @@ const ALT_SCHEMA = [
   { name: "windspeed", title: "Alternative wind speed sensor", selector: { entity: { domain: 'sensor' } } },
   { name: "dew_point", title: "Alternative dew pointsensor", selector: { entity: { domain: 'sensor' } } },
   { name: "wind_gust_speed", title: "Alternative wind gust speed sensor", selector: { entity: { domain: 'sensor' } } },
-  { name: "visibility", title: "Alternative visibility sensor", selector: { entity: { domain: 'sensor' } } },
+  { name: "visibility_entity", title: "Alternative visibility sensor", selector: { entity: { domain: 'sensor' } } },
 ];
 
 class WeatherChartCardEditor extends LitElement {
@@ -61,15 +61,15 @@ class WeatherChartCardEditor extends LitElement {
       this.hass &&
       this.hass.states[config.entity] &&
       this.hass.states[config.entity].attributes &&
-      this.hass.states[config.entity].attributes.visibility !== undefined
-    ) || config.visibility !== undefined;
+      this.hass.states[config.entity].attributes.visibility_entity !== undefined
+    ) || config.visibility_entity !== undefined;
     this.hasDescription = (
       this.hass &&
       this.hass.states[config.entity] &&
       this.hass.states[config.entity].attributes &&
       this.hass.states[config.entity].attributes.description !== undefined
     ) || config.description !== undefined;
-    this.fetchEntities();	  
+    this.fetchEntities();
     this.requestUpdate();
   }
 


### PR DESCRIPTION
# WHAT 

Renames the `visibility` card option config variable to `visibility_entity`.

**⚠️ It will introduce breaking change for people who were using `visibility` custom sensor. After this change it will have to be renamed to `visibility_entity`:warning:**

# WHY

So that it won't clash with `visibility` card configuration in home assistant.
The clash were making card fail when any condition for native HA visibility were set.

| HA visibility screen |  Card alternative entities before change | Card alternative entities after change |
| --- | --- | --- |
| <img width="200" alt="image" src="https://github.com/user-attachments/assets/49dac43a-f7ae-40a3-863b-b633656e9e6a"> | <img width="200" alt="image" src="https://github.com/user-attachments/assets/a652c76e-505b-4b05-8118-5d1b7095daf7"> | <img width="200" alt="image" src="https://github.com/user-attachments/assets/1a63c28d-a8fc-4045-a22d-8adec60273e7"> |
Config yaml prior the change:
```yaml
type: custom:weather-chart-card
entity: weather.house
show_main: false
show_temperature: false
show_current_condition: false
show_attributes: true
show_time: false
show_time_seconds: false
show_day: false
show_date: false
show_humidity: false
show_pressure: false
show_wind_direction: false
show_wind_speed: false
show_sun: false
show_feels_like: false
show_dew_point: false
show_wind_gust_speed: false
show_visibility: true
show_last_changed: false
use_12hour_format: false
icons_size: 25
animated_icons: false
icon_style: style1
autoscroll: false
forecast:
  precipitation_type: rainfall
  show_probability: false
  labels_font_size: "11"
  precip_bar_size: "100"
  style: style1
  show_wind_forecast: false
  condition_icons: false
  round_temp: false
  type: daily
  number_of_forecasts: "1"
  disable_animation: false
units:
  speed: ""
visibility:
  condition: screen
  media_query: "(min-width: 768px)"
```
Config yaml after the change:
```yaml
type: custom:weather-chart-card
entity: weather.house
show_main: false
show_temperature: false
show_current_condition: false
show_attributes: true
show_time: false
show_time_seconds: false
show_day: false
show_date: false
show_humidity: false
show_pressure: false
show_wind_direction: false
show_wind_speed: false
show_sun: false
show_feels_like: false
show_dew_point: false
show_wind_gust_speed: false
show_visibility: true
show_last_changed: false
use_12hour_format: false
icons_size: 25
animated_icons: false
icon_style: style1
autoscroll: false
forecast:
  precipitation_type: rainfall
  show_probability: false
  labels_font_size: "11"
  precip_bar_size: "100"
  style: style1
  show_wind_forecast: false
  condition_icons: false
  round_temp: false
  type: daily
  number_of_forecasts: "1"
  disable_animation: false
units:
  speed: ""
visibility:
  - condition: screen
    media_query: "(min-width: 768px)"
visibility_entity: sensor.fan_speed
```
Card *not rendered* before change when visibility condition (not visibility card options) filled:
<img width="501" alt="image" src="https://github.com/user-attachments/assets/7f701961-6929-46c6-822d-11325e6bbcf8">

Card *rendered* after change:
<img width="472" alt="image" src="https://github.com/user-attachments/assets/3eda5e60-2a60-4688-b62d-91d4f2921721">



 